### PR TITLE
docs: Insert a missing comma in azure-devops-yaml-schema pipeline.md

### DIFF
--- a/content/pipeline.md
+++ b/content/pipeline.md
@@ -117,7 +117,7 @@ This hierarchy is reflected in the structure of a YAML file like:
     - ...
 
 Simple pipelines don't require all of these levels.
-For example, in a single-job build you can omit the containers for stages and jobs because there are only steps.
+For example, in a single-job build, you can omit the containers for stages and jobs because there are only steps.
 And because many options shown in this article aren't required and have good defaults, your YAML definitions are unlikely to include all of them.
 
 ::: moniker-end


### PR DESCRIPTION
Inserted a comma immediately after "build" in the following sentence (found in azure-devops-yaml-schema pipeline.md):

"For example, in a single-job build you can omit the containers for stages and jobs because there are only steps."