### PR TITLE
Only the pipeline trigger section on the default branch is used

### DIFF
--- a/content/resources-pipelines-pipeline.md
+++ b/content/resources-pipelines-pipeline.md
@@ -974,7 +974,7 @@ For more information about pipeline resource triggers, see [pipeline-completion 
 ### Pipeline resource trigger syntax
 
 > [!NOTE]
-> Only the trigger section defined in the pipeline YAML file on your default branch will be used to determine when this pipeline is triggered.
+> Pipeline completion triggers use the [Default branch for manual and scheduled builds](/azure/devops/pipelines/process/pipeline-default-branch) setting to determine which branch's version of a YAML pipeline's branch filters to evaluate when determining whether to run a pipeline as the result of another pipeline completing. By default this setting points to the default branch of the repository. For more information, see [Pipeline completion triggers - branch considerations](/azure/devops/pipelines/process/pipeline-triggers#branch-considerations).
 
 :::moniker-end
 

--- a/content/resources-pipelines-pipeline.md
+++ b/content/resources-pipelines-pipeline.md
@@ -973,6 +973,9 @@ For more information about pipeline resource triggers, see [pipeline-completion 
 
 ### Pipeline resource trigger syntax
 
+> [!NOTE]
+> Only the trigger section defined in the pipeline YAML file on your default branch will be used to determine when this pipeline is triggered.
+
 :::moniker-end
 
 :::moniker range=">= azure-pipelines-2020"


### PR DESCRIPTION
When I was trying to set up a pipeline to automatically trigger after another pipeline had completed I found that the pipeline was only using the pipeline trigger section as defined on the default branch