### PR TITLE
Change UsePythonVersion documentation to use the new syntax

### DIFF
--- a/task-reference/use-python-version-v0.md
+++ b/task-reference/use-python-version-v0.md
@@ -186,6 +186,8 @@ This task will fail if no Python versions are found in `Agent.ToolsDirectory`. A
 
 As of version 0.150 of the task, version spec will also accept `pypy2` or `pypy3`.
 
+As of version 0.213.1 of the task, version spec will also accept `pypy2.x` or `pypy3.x`.
+
 ::: moniker-end
 
 If the task completes successfully, the task's output variable will contain the directory of the Python installation:


### PR DESCRIPTION
After [PR](https://github.com/microsoft/azure-pipelines-tasks/pull/16377/files), the behaviour of versionSpec has been changed, now it allows setting 'pypy2.x' or 'pypy'3.x' on task version 0.213.1 and upper.