### PR TITLE
Fix the link to the Nuget Tool Installer

### DIFF
--- a/task-reference/nuget-command-v2.md
+++ b/task-reference/nuget-command-v2.md
@@ -615,7 +615,7 @@ If your code depends on NuGet packages, make sure to add this step before your [
 If you are working with .NET Core or .NET Standard, use the [.NET Core](dotnet-core-cli-v2.md) task, which has full support for all package scenarios and is currently supported by dotnet.
 
 > [!TIP]
-> This version of the NuGet task uses NuGet 4.1.0 by default. To select a different version of NuGet, use the [Tool Installer](nuget-installer-v0.md).
+> This version of the NuGet task uses NuGet 4.1.0 by default. To select a different version of NuGet, use the [Tool Installer](nuget-tool-installer-v1.md).
 
 ### Versioning schemes
 


### PR DESCRIPTION
In the doc of the ADO NuGet command, the link to the NuGet Tool installer is currently a link to the NuGet installer which installs a NuGet package and not NuGet.exe.
This PR fixes this.