### PR TITLE
More concise language on PowerShell versions used

### DIFF
--- a/task-reference/azure-powershell-v5.md
+++ b/task-reference/azure-powershell-v5.md
@@ -12,6 +12,9 @@ monikerRange: ">=azure-pipelines-2020"
 
 <!-- :::editable-content name="description"::: -->
 Use this task to run a PowerShell script within an Azure environment. The Azure context is authenticated with the provided Azure Resource Manager service connection.
+
+>[!NOTE]
+> By default, Azure PowerShell v5 uses PowerShell Core for Linux agents and Windows PowerShell for Windows agents. To use the latest version of PowerShell on Windows agents, set the `pwsh` parameter to `true`. PowerShell Core will then be used instead.
 <!-- :::editable-content-end::: -->
 
 :::moniker-end
@@ -38,7 +41,7 @@ Use this task to run a PowerShell script within an Azure environment. The Azure 
     #azurePowerShellVersion: 'OtherVersion' # 'LatestVersion' | 'OtherVersion'. Alias: TargetAzurePs. Azure PowerShell Version. Default: OtherVersion.
     preferredAzurePowerShellVersion: # string. Alias: CustomTargetAzurePs. Required when TargetAzurePs = OtherVersion. Preferred Azure PowerShell Version. 
   # Advanced
-    #pwsh: false # boolean. Use PowerShell Core. Default: false.
+    #pwsh: false # boolean. Use PowerShell Core instead of Windows PowerShell (Windows agents only). Default: false.
     #workingDirectory: # string. Working Directory.
 ```
 
@@ -165,7 +168,7 @@ The preferred Azure PowerShell Version needs to be a proper semantic version eg.
 **`pwsh`** - **Use PowerShell Core**<br>
 `boolean`. Default value: `false`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-If this is true, then on Windows the task will use `pwsh.exe` from your path instead of `powershell.exe`.
+If this is true, then tasks running on Windows agents will use `pwsh.exe` from your path instead of `powershell.exe`.
 <!-- :::editable-content-end::: -->
 <br>
 

--- a/task-reference/azure-powershell-v5.md
+++ b/task-reference/azure-powershell-v5.md
@@ -41,7 +41,7 @@ Use this task to run a PowerShell script within an Azure environment. The Azure 
     #azurePowerShellVersion: 'OtherVersion' # 'LatestVersion' | 'OtherVersion'. Alias: TargetAzurePs. Azure PowerShell Version. Default: OtherVersion.
     preferredAzurePowerShellVersion: # string. Alias: CustomTargetAzurePs. Required when TargetAzurePs = OtherVersion. Preferred Azure PowerShell Version. 
   # Advanced
-    #pwsh: false # boolean. Use PowerShell Core instead of Windows PowerShell (Windows agents only). Default: false.
+    #pwsh: false # boolean. Use PowerShell Core. Default: false.
     #workingDirectory: # string. Working Directory.
 ```
 

--- a/task-reference/powershell-v2.md
+++ b/task-reference/powershell-v2.md
@@ -45,7 +45,7 @@ Use this task to run a PowerShell script on Linux, macOS, or Windows.
     #failOnStderr: false # boolean. Fail on Standard Error. Default: false.
     #showWarnings: false # boolean. Show warnings as Azure DevOps warnings. Default: false.
     #ignoreLASTEXITCODE: false # boolean. Ignore $LASTEXITCODE. Default: false.
-    #pwsh: false # boolean. Use PowerShell Core instead of Windows PowerShell (Windows agents only). Default: false.
+    #pwsh: false # boolean. Use PowerShell Core. Default: false.
     #workingDirectory: # string. Working Directory. 
     #runScriptInSeparateScope: false # boolean. Run script in the separate scope. Default: false.
 ```

--- a/task-reference/powershell-v2.md
+++ b/task-reference/powershell-v2.md
@@ -12,6 +12,9 @@ monikerRange: "<=azure-pipelines"
 
 <!-- :::editable-content name="description"::: -->
 Use this task to run a PowerShell script on Linux, macOS, or Windows.
+
+>[!NOTE]
+> By default, Azure PowerShell v5 uses PowerShell Core for Linux agents and Windows PowerShell for Windows agents. To use the latest version of PowerShell on Windows agents, set the `pwsh` parameter to `true`. PowerShell Core will then be used instead.
 <!-- :::editable-content-end::: -->
 
 :::moniker-end
@@ -42,7 +45,7 @@ Use this task to run a PowerShell script on Linux, macOS, or Windows.
     #failOnStderr: false # boolean. Fail on Standard Error. Default: false.
     #showWarnings: false # boolean. Show warnings as Azure DevOps warnings. Default: false.
     #ignoreLASTEXITCODE: false # boolean. Ignore $LASTEXITCODE. Default: false.
-    #pwsh: false # boolean. Use PowerShell Core. Default: false.
+    #pwsh: false # boolean. Use PowerShell Core instead of Windows PowerShell (Windows agents only). Default: false.
     #workingDirectory: # string. Working Directory. 
     #runScriptInSeparateScope: false # boolean. Run script in the separate scope. Default: false.
 ```
@@ -352,7 +355,7 @@ If the value is set to `false`, the line `if ((Test-Path -LiteralPath variable:\
 **`pwsh`** - **Use PowerShell Core**<br>
 `boolean`. Default value: `false`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-If the value is set to `true`, the task will use `pwsh.exe` from your PATH instead of `powershell.exe` on a Windows agent.
+If this is true, then tasks running on Windows agents will use `pwsh.exe` from your path instead of `powershell.exe`.
 <!-- :::editable-content-end::: -->
 <br>
 


### PR DESCRIPTION
I noticed that the PowerShell version changed after switching from a Linux agent to a Windows agent. By default, Linux agents uses PowerShell Core, regardless of the whether the parameter `pwsh` is set to true or false. For Windows agents on the other hand, it determines whether PowerShell Core or Windows PowerShell 5.1 is used (the latter is the default). Therefore my pipeline changed from version 7.x to 5.1 since I didn't specify the parameter in my task and it used the default setting.

I propose the following changes to make this more clear:
- "Note" box in the module description highlighting this inconsistency
  - Alternatively put this under a *Remarks* sub chapter
- More concise language in the parameter descriptions
  - Should I also explicitly state that this parameter is ignored on Linux agents?

Please let me know what you think
