### PR TITLE
Change JavaToolInstaller@0 documentation since ms-hosted images don't use x86 pre-installed version anymore(only x64)

### DIFF
--- a/task-reference/java-tool-installer-v0.md
+++ b/task-reference/java-tool-installer-v0.md
@@ -358,7 +358,7 @@ Here's an example of using "pre-installed" feature. This feature allows you to u
 - task: JavaToolInstaller@0
   inputs:
     versionSpec: '8'
-    jdkArchitectureOption: 'x86'
+    jdkArchitectureOption: 'x64'
     jdkSourceOption: 'PreInstalled'
 ```
 <!-- :::editable-content-end::: -->


### PR DESCRIPTION
The main page of the task (https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/java-tool-installer-v0?view=azure-pipelines#examples) refers us to ms-hosted pool specifications, but, currently, has only x64 preinstalled java 8, with env variable JAVA_HOME_8_X64, but the example set jdkArchitectureOption: 'x86' which is incorrect and won't work for ms-hosted agents, so, for compatibility with ms-hosted pools, better to change it to x64, which helping to escape misunderstanding when users copy code and paste in the pipelines.