### PR TITLE
Update azure-powershell-v2.md

### DIFF
--- a/task-reference/azure-powershell-v2.md
+++ b/task-reference/azure-powershell-v2.md
@@ -143,7 +143,7 @@ The additional parameters to pass to PowerShell. These can be either ordinal or 
 **`azurePowerShellVersion`** - **Azure PowerShell Version**<br>
 Input alias: `TargetAzurePs`. `string`. Allowed values: `LatestVersion` (Latest installed version), `OtherVersion` (Specify other version). Default value: `OtherVersion`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-In case of hosted agents, the supported Azure PowerShell Versions are `2.1.0`, `3.8.0`, `4.2.1`, `5.1.1` and `6.7.0` (Hosted VS2017 Queue).
+In case of hosted agents, the supported Azure PowerShell Versions are `2.1.0`, `3.8.0`, `4.2.1`, `5.1.1` and `6.7.0`.
 To pick the latest version available on the agent, select `LatestVersion` (Latest installed version).
 
 For private agents you can specify a preferred version of Azure PowerShell using `OtherVersion` (Specify other version).
@@ -158,7 +158,7 @@ For private agents you can specify a preferred version of Azure PowerShell using
 **`preferredAzurePowerShellVersion`** - **Preferred Azure PowerShell Version**<br>
 Input alias: `CustomTargetAzurePs`. `string`. Required when `TargetAzurePs = OtherVersion`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-The preferred Azure PowerShell Version needs to be a proper semantic version eg. `1.2.3.`. Regex like `2.\*,2.3.\*` is not supported. The Hosted VS2017 Pool currently supports Azure module versions `2.1.0`, `3.8.0`, `4.2.1`, `5.1.1` and AzureRM module versions `2.1.0`, `3.8.0`, `4.2.1`, `5.1.1`, `6.7.0`.
+The preferred Azure PowerShell Version needs to be a proper semantic version eg. `1.2.3.`. Regex like `2.\*,2.3.\*` is not supported. Hosted agents currently supports Azure module versions `2.1.0`, `3.8.0`, `4.2.1`, `5.1.1` and AzureRM module versions `2.1.0`, `3.8.0`, `4.2.1`, `5.1.1`, `6.7.0`.
 <!-- :::editable-content-end::: -->
 <br>
 


### PR DESCRIPTION
Hosted agent 2017 has been retired and should be removed from the documentation. Removed references to specific image versions as the AzureRM module is still present in the current Microsoft-hosted agents image. https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/

https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md AzureRM (Cached): 3.8.0.zip, 4.2.1.zip, 5.1.1.zip, 6.7.0.zip

https://github.com/actions/runner-images/blob/main/images/win/Windows2019-Readme.md AzureRM (Cached): 3.8.0.zip, 4.2.1.zip, 5.1.1.zip, 6.7.0.zip

Thank you for your contribution. Please see the README.MD in this repo for details on how to contribute.

- [ ] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [ ] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.