### PR TITLE
Typo "Mysql"→"MySQL"

### DIFF
--- a/task-reference/mysql-deployment-on-machine-group-v1.md
+++ b/task-reference/mysql-deployment-on-machine-group-v1.md
@@ -34,7 +34,7 @@ Use this task to run your scripts and make changes to your MySQL Database. There
     #SqlInline: # string. Required when TaskNameSelector = InlineSqlTask. Inline MySQL Script. 
     ServerName: 'localhost' # string. Required. Host Name. Default: localhost.
     #DatabaseName: # string. Database Name. 
-    SqlUsername: # string. Required. Mysql User Name. 
+    SqlUsername: # string. Required. MySQL User Name. 
     SqlPassword: # string. Required. Password. 
     #SqlAdditionalArguments: # string. Additional Arguments.
 ```
@@ -108,7 +108,7 @@ Specifies the name of the database. The script will create a database name if on
 <!-- :::item name="SqlUsername"::: -->
 :::moniker range=">=azure-pipelines-2019.1"
 
-**`SqlUsername`** - **Mysql User Name**<br>
+**`SqlUsername`** - **MySQL User Name**<br>
 `string`. Required.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
 This string is the same value that is used for `Username` in `Parameters` in MySQL Workbench.


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/mysql-deployment-on-machine-group-v1?view=azure-pipelines 
https://github.com/MicrosoftDocs/azure-devops-yaml-schema/blob/main/task-reference/mysql-deployment-on-machine-group-v1.md 
#PingMSFTDocs

Thank you for your contribution. Please see the README.MD in this repo for details on how to contribute.

- [ ] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [ ] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.