### PR TITLE
docs: Clarify meaning behind "trigger: none", in trigger.md

### DIFF
--- a/content/trigger.md
+++ b/content/trigger.md
@@ -129,7 +129,7 @@ Disable CI triggers.
 ### Examples
 
 ```yaml
-trigger: none # will disable CI builds entirely
+trigger: none # will not run CI builds (outside of pull request events)
 ```
 <!-- :::editable-content-end::: -->
 <!-- :::examples-end::: -->


### PR DESCRIPTION
Hi there!

I'd like to propose this change, as we found this comment to be misleading - when the `pr:` key is added as well as `trigger:`, we found that CI builds still ran on Pull Request events, therefore not "Disabling CI Builds entirely" as the comment suggests.

Very happy to make other edits to make this clearer. Cheers 😄 