### PR TITLE
Update publish-code-coverage-results-v1.md

### DIFF
--- a/task-reference/publish-code-coverage-results-v1.md
+++ b/task-reference/publish-code-coverage-results-v1.md
@@ -100,6 +100,9 @@ Specifies the path of the summary file containing code coverage statistics, such
 Specifying a path to source files is required when coverage XML reports don't contain an absolute path to source files. For example, JaCoCo reports don't use absolute paths, so when publishing JaCoCo coverage for Java apps, the pattern is similar to `$(System.DefaultWorkingDirectory)/MyApp/src/main/java/`. This input should point to an absolute path to source files on the host. For example, `$(System.DefaultWorkingDirectory)/MyApp/`.
 
 This input can be used if tests are run in a Docker container.
+
+Multiple sources can be added by delimiting each list item with the ';' character.
+Eg: pathToSources: $(System.DefaultWorkingDirectory)/path/to/first/source;$(System.DefaultWorkingDirectory)/path/to/second/source
 <!-- :::editable-content-end::: -->
 <br>
 

--- a/task-reference/publish-code-coverage-results-v1.md
+++ b/task-reference/publish-code-coverage-results-v1.md
@@ -101,8 +101,7 @@ Specifying a path to source files is required when coverage XML reports don't co
 
 This input can be used if tests are run in a Docker container.
 
-Multiple sources can be added by delimiting each list item with the ';' character.
-Eg: pathToSources: $(System.DefaultWorkingDirectory)/path/to/first/source;$(System.DefaultWorkingDirectory)/path/to/second/source
+Multiple sources can be added by delimiting each list item with the `;` character, for example `pathToSources: $(System.DefaultWorkingDirectory)/path/to/first/source;$(System.DefaultWorkingDirectory)/path/to/second/source`.
 <!-- :::editable-content-end::: -->
 <br>
 


### PR DESCRIPTION
I have appended a note to the 'pathToSources' option about how to specify multiple source paths, for users that implement Maven multi-module projects that depend on one another.