### PR TITLE
Update SymbolsArtifactName parameter documentation of PublishSymbolsV2 task

### DIFF
--- a/task-reference/publish-symbols-v2.md
+++ b/task-reference/publish-symbols-v2.md
@@ -321,7 +321,7 @@ Specifies the version parameter to `symstore.exe`.  The default is `$(Build.Buil
 **`SymbolsArtifactName`** - **Artifact name**<br>
 `string`. Default value: `Symbols_$(BuildConfiguration)`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-Specifies the artifact name to use for the symbols artifact.  The default is `Symbols_$(BuildConfiguration)`.
+Specifies the artifact name to use for the symbols artifact. This should only be used with the FileShare symbol server type.  The default is `Symbols_$(BuildConfiguration)`.
 <!-- :::editable-content-end::: -->
 <br>
 


### PR DESCRIPTION
Update SymbolsArtifactName parameter documentation of PublishSymbolsV2 task to specify that it should only be used with the FileShare symbol server type

Thank you for your contribution. Please see the README.MD in this repo for details on how to contribute.

- [ ] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [ ] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.