### PR TITLE
Removing Required from notifyUsers

### DIFF
--- a/task-reference/manual-validation-v0.md
+++ b/task-reference/manual-validation-v0.md
@@ -27,7 +27,7 @@ Use this task to pause a YAML pipeline run to wait for manual interaction.
 # [PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.
 - task: ManualValidation@0
   inputs:
-    notifyUsers: # string. Required. Notify users. 
+    notifyUsers: # string. Notify users. 
     #instructions: # string. Instructions. 
     #onTimeout: 'reject' # 'reject' | 'resume'. On timeout. Default: reject.
 ```
@@ -42,11 +42,11 @@ Use this task to pause a YAML pipeline run to wait for manual interaction.
 :::moniker range=">=azure-pipelines-2020.1"
 
 **`notifyUsers`** - **Notify users**<br>
-`string`. Required.<br>
+`string`. <br>
 <!-- :::editable-content name="helpMarkDown"::: -->
 Sends a manual validation pending email to specific users (or groups). Only users with queue build permission can act on a manual validation. You can send an email to a group using the `[org name]\group name` syntax.
 
-This task input is required, but you can specify an empty string if you don't want to notify anyone, for example during a test run: `notifyUsers: ''`.
+If not specified, no notification is sent.
 <!-- :::editable-content-end::: -->
 <br>
 


### PR DESCRIPTION
Thank you for your contribution. Please see the README.MD in this repo for details on how to contribute.

- [ ] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [ ] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.