### PR TITLE
Fix inline code block --collect “Code coverage”

### DIFF
--- a/task-reference/dotnet-core-cli-v2.md
+++ b/task-reference/dotnet-core-cli-v2.md
@@ -299,7 +299,7 @@ Enabling this option will generate a `test results` TRX file in `$(Agent.TempDir
 This option appends `--logger trx --results-directory $(Agent.TempDirectory)` to the command line arguments.
 
 
-Code coverage can be collected by adding the `--collect “Code coverage”` option to the command line arguments.
+Code coverage can be collected by adding the `--collect "Code coverage"` option to the command line arguments.
 <!-- :::editable-content-end::: -->
 <br>
 
@@ -315,7 +315,7 @@ Enabling this option will generate a `test results` TRX file in `$(Agent.TempDir
 This option appends the `--logger trx --results-directory $(Agent.TempDirectory)` to the command line arguments.
 
 
-Code coverage can be collected by adding the `--collect “Code coverage”` option to the command line arguments.
+Code coverage can be collected by adding the `--collect "Code coverage"` option to the command line arguments.
 <!-- :::editable-content-end::: -->
 <br>
 


### PR DESCRIPTION
... to use simple quotes instead of curved ones

Thank you for your contribution. Please see the README.MD in this repo for details on how to contribute.

- [ ] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [x] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.