### PR TITLE
Updating description of CopyFile@v2 behaviour

### DIFF
--- a/task-reference/copy-files-v2.md
+++ b/task-reference/copy-files-v2.md
@@ -245,7 +245,10 @@ None.
 <!-- :::editable-content name="remarks"::: -->
 ## Remarks
 
-If no files match, the task will still report success. If a matched file already exists in the target folder, the task will not report failure but mention that the file already exists and skip it. Use and set `Overwrite` to `true` to replace existing files. 
+If no files match, the task will still report success.
+
+* If `Overwrite` is `false` and a matched file already exists in the target folder, the task will not report failure but log that the file already exists and skip it.
+* If `Overwrite` is `true` and a matched file already exists in the target folder, the matched file will be overwritten.
 <!-- :::editable-content-end::: -->
 <!-- :::remarks-end::: -->
 

--- a/task-reference/copy-files-v2.md
+++ b/task-reference/copy-files-v2.md
@@ -245,7 +245,7 @@ None.
 <!-- :::editable-content name="remarks"::: -->
 ## Remarks
 
-If no files match, the task will still report success. If a matched file already exists in the target folder, the task will report failure unless `Overwrite` is set to true.
+If no files match, the task will still report success. If a matched file already exists in the target folder, the task will not report failure but mention that the file already exists and skip it. Use and set `Overwrite` to `true` to replace existing files. 
 <!-- :::editable-content-end::: -->
 <!-- :::remarks-end::: -->
 


### PR DESCRIPTION
I'm updating this definition since it is not the current behaviour of the task. It will reduce confusion of the behaviour for this task.

Thanks.

---

Thank you for your contribution. Please see the README.MD in this repo for details on how to contribute.

- [ ] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [x] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.