### PR TITLE
[editable-content] Update kubernetes-v1.md to add the use of Scale

### DIFF
--- a/task-reference/kubernetes-v1.md
+++ b/task-reference/kubernetes-v1.md
@@ -330,7 +330,7 @@ Set the namespace for the kubectl command by using the –namespace flag. If the
 **`command`** - **Command**<br>
 `string`. Allowed values: `apply`, `create`, `delete`, `exec`, `expose`, `get`, `login`, `logout`, `logs`, `run`, `set`, `top`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-Select or specify a kubectl command to run. The list of allowed values provides some common choices for ease of selection when using the task assistant, but you can specify other `kubectl` commands such as `scale`. Use the `arguments` input to specify additional parameters to the specified `kubectl` command.
+Select or specify a kubectl command to run. The list of allowed values provides some common choices for ease of selection when using the task assistant, but you can specify other [kubectl commands](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands) such as `scale`. Use the `arguments` input to specify additional parameters to the specified `kubectl` command.
 <!-- :::editable-content-end::: -->
 <br>
 

--- a/task-reference/kubernetes-v1.md
+++ b/task-reference/kubernetes-v1.md
@@ -328,7 +328,7 @@ Set the namespace for the kubectl command by using the –namespace flag. If the
 :::moniker range=">=azure-pipelines-2019.1"
 
 **`command`** - **Command**<br>
-`string`. Allowed values: `apply`, `create`, `delete`, `exec`, `expose`, `get`, `login`, `logout`, `logs`, `run`, `set`, `top`.<br>
+`string`. Allowed values: `apply`, `create`, `delete`, `exec`, `expose`, `get`, `login`, `logout`, `logs`, `run`, `set`, `top`, `scale`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
 Select or specify a kubectl command to run.
 <!-- :::editable-content-end::: -->
@@ -849,6 +849,17 @@ This YAML example demonstrates the use of a configuration file with the **apply*
     configuration: mhc-aks.yaml
 ```
 
+This YAML example shows the use of how to use the **scale** command to decrease the number of replicas in a deployment to 0
+```YAML
+- task: Kubernetes@1
+      displayName: 'Scale down deployment $(k8sDeployment) to 0'
+      inputs:
+        connectionType: 'Kubernetes Service Connection'
+        kubernetesServiceEndpoint: $(kubernetesServiceConnection)
+        command: 'scale'
+        arguments: 'deployment/$(k8sDeployment) --replicas=0'
+        namespace: $(namespace)
+```
 ### Secrets
 
 Kubernetes objects of type **secret** are intended to hold sensitive information such as passwords, OAuth tokens, and ssh keys. Putting this information in a secret is safer and more flexible than putting it verbatim in a pod definition or in a Docker image. Azure Pipelines simplifies the addition of `ImagePullSecrets` to a service account, or setting up of any generic secret, as described below.

--- a/task-reference/kubernetes-v1.md
+++ b/task-reference/kubernetes-v1.md
@@ -330,7 +330,7 @@ Set the namespace for the kubectl command by using the –namespace flag. If the
 **`command`** - **Command**<br>
 `string`. Allowed values: `apply`, `create`, `delete`, `exec`, `expose`, `get`, `login`, `logout`, `logs`, `run`, `set`, `top`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-Select or specify a kubectl command to run. The list of allowed values provides some common choices for ease of selection when using the task assistant, but you can specify other `kubectl` commands such as `scale`. Use the `arguments` inpt to specify additional parameters to the specified `kubectl` command.
+Select or specify a kubectl command to run. The list of allowed values provides some common choices for ease of selection when using the task assistant, but you can specify other `kubectl` commands such as `scale`. Use the `arguments` input to specify additional parameters to the specified `kubectl` command.
 <!-- :::editable-content-end::: -->
 <br>
 

--- a/task-reference/kubernetes-v1.md
+++ b/task-reference/kubernetes-v1.md
@@ -328,9 +328,9 @@ Set the namespace for the kubectl command by using the –namespace flag. If the
 :::moniker range=">=azure-pipelines-2019.1"
 
 **`command`** - **Command**<br>
-`string`. Allowed values: `apply`, `create`, `delete`, `exec`, `expose`, `get`, `login`, `logout`, `logs`, `run`, `set`, `top`, `scale`.<br>
+`string`. Allowed values: `apply`, `create`, `delete`, `exec`, `expose`, `get`, `login`, `logout`, `logs`, `run`, `set`, `top`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-Select or specify a kubectl command to run.
+Select or specify a kubectl command to run. The list of allowed values provides some common choices for ease of selection when using the task assistant, but you can specify other `kubectl` commands such as `scale`. Use the `arguments` inpt to specify additional parameters to the specified `kubectl` command.
 <!-- :::editable-content-end::: -->
 <br>
 
@@ -817,9 +817,7 @@ This YAML example shows how a Kubernetes Service Connection is used to refer to 
 
 ### Commands
 
-The command input accepts one of the following [kubectl commands](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands):
-
-**apply**, **create**, **delete**, **exec**, **expose**, **get**, **login**, **logout**, **logs**, **run**, **set**, or **top**.
+The command input accepts [kubectl commands](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands).
 
 This YAML example demonstrates the **apply** command:
 
@@ -834,6 +832,7 @@ This YAML example demonstrates the **apply** command:
     command: apply
     arguments: -f mhc-aks.yaml
 ```
+
 This YAML example demonstrates the use of a configuration file with the **apply** command:
 
 ```YAML
@@ -849,7 +848,8 @@ This YAML example demonstrates the use of a configuration file with the **apply*
     configuration: mhc-aks.yaml
 ```
 
-This YAML example shows the use of how to use the **scale** command to decrease the number of replicas in a deployment to 0
+This YAML example shows the use of how to use the **scale** command to decrease the number of replicas in a deployment to 0.
+
 ```YAML
 - task: Kubernetes@1
       displayName: 'Scale down deployment $(k8sDeployment) to 0'


### PR DESCRIPTION
Add the use of scale

Thank you for your contribution. Please see the README.MD in this repo for details on how to contribute.

- [ ] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [x] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.