### PR TITLE
Tweak the wording for the tags argument for the Docker task

### DIFF
--- a/task-reference/docker-v2.md
+++ b/task-reference/docker-v2.md
@@ -206,7 +206,7 @@ Specifies the path to the build context. Pass `**` to indicate the directory tha
 **`tags`** - **Tags**<br>
 `string`. Optional. Use when `command = build || command = push || command = buildAndPush`. Default value: `$(Build.BuildId)`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-Specifies a list of tags on separate lines. These tags are used in `build`, `push` and `buildAndPush` commands.
+Specifies a list of comma-separated tags. These tags are used in `build`, `push` and `buildAndPush` commands.
 <!-- :::editable-content-end::: -->
 <br>
 


### PR DESCRIPTION
Currently the docs specify that tags to this particular task are passed on "separate lines", but as per this [SO thread](https://stackoverflow.com/questions/76782526/azure-devops-docker-task-with-multiple-tags) and my own tests, it actually expects a comma-separated list. This should just update that

**Template:**

Thank you for your contribution. Please see the README.MD in this repo for details on how to contribute.

- [X] Are you creating a new task article?
  - No
- [X] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.
  - Understood, and hopefully followed