### PR TITLE
pwsh is for inline only

### DIFF
--- a/content/steps-pwsh.md
+++ b/content/steps-pwsh.md
@@ -22,7 +22,7 @@ The `pwsh` step runs a script in PowerShell Core on Windows, macOS, and Linux.
 
 ```yaml
 steps:
-- pwsh: string # Required as first property. Inline PowerShell or reference to a PowerShell file.
+- pwsh: string # Required as first property. Inline PowerShell.
   errorActionPreference: string # Unless otherwise specified, the error action preference defaults to the value stop. See the following section for more information.
   failOnStderr: string # Fail the task if output is sent to Stderr?
   ignoreLASTEXITCODE: string # Check the final exit code of the script to determine whether the step succeeded?


### PR DESCRIPTION
Updating documentation to reflect that the pwsh shortcut is not for file references.

According to this Visual Studio Community answer from a Microsoft employee and my experience, the pwsh task short cut does not use file references.

Visual Studio Community: https://developercommunity.visualstudio.com/t/pipelines-yaml-pwsh-shortcut-differs-in-behavior-f/726768#TPIN-N786841

My personal experience: Create a yaml pipeline with the pwsh task and specify a file.
```yaml
    - pwsh: ./script.ps1
      displayName: Run script
      continueOnError: false
```
After the pipeline runs, you can download the logs and see that the pwsh shortcut is transformed into a PowerShell@2 task with the targetType set as inline.
```yaml
    - task: PowerShell@2
      displayName: Run script
      continueOnError: false
      inputs:
        targetType: inline
        script: ./script.ps1
        pwsh: true
```
The task fails because it is not an inline script.  It is a filePath reference.