### PR TITLE
Document that target can be a branch

### DIFF
--- a/task-reference/github-release-v1.md
+++ b/task-reference/github-release-v1.md
@@ -98,7 +98,7 @@ Specifies the type of release operation to perform. This task can create, edit, 
 **`target`** - **Target**<br>
 `string`. Required when `action = create || action = edit`. Default value: `$(Build.SourceVersion)`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-Specifies the commit SHA you want to use to create the GitHub release, for example `48b11d8d6e92a22e3e9563a3f643699c16fd6e27`. You can also use a variable, like `$(myCommitSHA)`, in this field.
+Specifies the commit SHA or branch name you want to use to create the GitHub release, for example `48b11d8d6e92a22e3e9563a3f643699c16fd6e27` or `main`. You can also use a variable, like `$(myCommitSHA)`, in this field.
 <!-- :::editable-content-end::: -->
 <br>
 


### PR DESCRIPTION
Based on https://github.com/microsoft/coe-starter-kit/blob/3d5598bcef607055d41bcaf9c11538558254e3a3/CenterofExcellenceResources/Release/Pipelines/CoEStarterKit/create-github-release.yml#L201 , this input can be a branch name.  Please confirm.  Hopefully, I'll be able to confirm soon.

- [ ] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [x] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.