### PR TITLE
Update azure-static-web-app-v0 to add deploy only example

### DIFF
--- a/task-reference/azure-static-web-app-v0.md
+++ b/task-reference/azure-static-web-app-v0.md
@@ -97,7 +97,7 @@ Specifies the absolute working directory in which to execute this task. If left 
 **`app_location`** - **App location**<br>
 `string`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-The directory location of the application source code, relative to the working directory.
+The directory location of the application source code, relative to the working directory. When used with skip_app_build: true, this value is the app's build output location.
 <!-- :::editable-content-end::: -->
 <br>
 
@@ -121,7 +121,7 @@ The custom command used to run Oryx when building application source code.
 **`output_location`** - **Output location**<br>
 `string`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-The directory location of the compiled application code after building is complete, relative to the working directory.
+The directory location of the compiled application code after building is complete, relative to the working directory. Set this an empty string (`''`) when bypassing automatic build and only deploy is required
 <!-- :::editable-content-end::: -->
 <br>
 
@@ -331,6 +331,35 @@ steps:
       api_location: 'api'
       output_location: '/output'
       azure_static_web_apps_api_token: $(deployment_token)
+```
+
+### Skip building front-end app and run only deploy
+```YAML
+
+trigger:
+- main
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '20.x'
+    displayName: 'Install Node.js'
+
+  - script: |
+      npm ci
+      npm run build
+    displayName: 'dependencies install and distribution build'
+
+- task: AzureStaticWebApp@0
+  inputs:
+    app_location : '/dist'
+    output_location: '' # Leave this empty
+    skip_app_build: true
+    skip_api_build: true
+    azure_static_web_apps_api_token: $(deployment_token)
 ```
 <!-- :::editable-content-end::: -->
 <!-- :::examples-end::: -->

--- a/task-reference/azure-static-web-app-v0.md
+++ b/task-reference/azure-static-web-app-v0.md
@@ -97,7 +97,7 @@ Specifies the absolute working directory in which to execute this task. If left 
 **`app_location`** - **App location**<br>
 `string`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-The directory location of the application source code, relative to the working directory. When used with skip_app_build: true, this value is the app's build output location.
+The directory location of the application source code, relative to the working directory. When used with `skip_app_build: true`, this value is the app's build output location.
 <!-- :::editable-content-end::: -->
 <br>
 
@@ -121,7 +121,7 @@ The custom command used to run Oryx when building application source code.
 **`output_location`** - **Output location**<br>
 `string`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-The directory location of the compiled application code after building is complete, relative to the working directory. Set this an empty string (`''`) when bypassing automatic build and only deploy is required
+The directory location of the compiled application code after building is complete, relative to the working directory. Set this an empty string (`''`) when bypassing automatic build and only deploy is required.
 <!-- :::editable-content-end::: -->
 <br>
 


### PR DESCRIPTION
Based on https://learn.microsoft.com/en-us/azure/static-web-apps/build-configuration?tabs=azure-devops#skip-building-front-end-app `app_location` and `output_location` work differently when used with `skip_app_build: true`.

- [ ] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [x] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.