### PR TITLE
Update azure static web app task output variables

### DIFF
--- a/task-reference/azure-static-web-app-v0.md
+++ b/task-reference/azure-static-web-app-v0.md
@@ -298,7 +298,10 @@ All tasks have control options in addition to their task inputs. For more inform
 
 :::moniker range=">=azure-pipelines-2022"
 
-None.
+This task defines the following output variables, which you can consume in downstream steps, jobs, and stages.
+
+**`AZURESTATICWEBAPP_STATIC_WEB_APP_URL`**
+Stores the URL of the deployed static web app.
 
 :::moniker-end
 <!-- :::outputVariables-end::: -->


### PR DESCRIPTION
It looks like the Azure Static Web Apps task has an [output variable](https://arc.net/l/quote/msdtuksi) (`AZURESTATICWEBAPP_STATIC_WEB_APP_URL`) which however is not documented in the [docs](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/azure-static-web-app-v0?view=azure-pipelines#output-variables).

P.S: I know this section might be auto generated, so I don't anticipate this PR being merged. But I wanted to bring this to attention since this can be particularly useful as static web apps generate _random_ URLs for preview environments.