### PR TITLE
use correct inputs mapping

### DIFF
--- a/task-reference/advanced-security-codeql-analyze-v1.md
+++ b/task-reference/advanced-security-codeql-analyze-v1.md
@@ -117,7 +117,7 @@ The analysis task must appear after the initialize task for successful completio
 # Initialize CodeQL database 
 - task: AdvancedSecurity-Codeql-Init@1
   inputs: 
-    language: csharp 
+    languages: 'csharp' 
   displayName: 'Advanced Security Initialize CodeQL' 
 
 # Build project using Autobuild or your own custom build steps 

--- a/task-reference/advanced-security-codeql-autobuild-v1.md
+++ b/task-reference/advanced-security-codeql-autobuild-v1.md
@@ -83,7 +83,7 @@ The `AdvancedSecurity-Codeql-Autobuild@1` task must appear after the initialize 
 # Initialize CodeQL database 
 - task: AdvancedSecurity-Codeql-Init@1
   inputs: 
-    language: csharp 
+    languages: 'csharp' 
   displayName: 'Advanced Security Initialize CodeQL' 
 
 # Build project using Autobuild or your own custom build steps 


### PR DESCRIPTION
The YAML samples state to use `language` inputs mapping, but it should be `languages`. Using `language` results in the following pipeline error:

```
##[warning] The language pipeline variable was not set.
##[warning] Either set a pipeline variable named advancedsecurity.codeql.language to the programming language to analyze,
##[warning] or set the Languages task setting to the programming language to analyze,
##[warning] Valid values for the languages are csharp,cpp,go,java,javascript,python,ruby,swift. Multiple languages can be separated by a comma.
##[warning] For more information, see https://aka.ms/codeQL-language-error
##
```

- [ ] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [ ] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.