### PR TITLE
Update resources-webhooks-webhook.md

### DIFF
--- a/content/resources-webhooks-webhook.md
+++ b/content/resources-webhooks-webhook.md
@@ -47,6 +47,7 @@ Definitions that reference this definition: [resources.webhooks](resources-webho
 
 **`webhook`** string. Required as first property.<br><!-- :::editable-content name="propDescription"::: -->
 Name of the webhook. Acceptable values: [-_A-Za-z0-9]*.
+For Azure DevOps webhook, `webhook` must always be a `WebHook`.
 <!-- :::editable-content-end::: -->
 
 :::moniker-end
@@ -102,7 +103,9 @@ steps:
 - script: echo ${{ parameters.WebHook.resource.message.title }}
 ```
 
-To trigger your pipeline using the webhook, you need to make a `POST` request to `https://dev.azure.com/<org_name>/_apis/public/distributedtask/webhooks/<webhook_connection_name>?api-version=6.0-preview`. This endpoint is publicly available, and no authorization is needed. The request should have the following body.
+To trigger your pipeline using the webhook, you need to make a `POST` request to `https://dev.azure.com/<org_name>/_apis/public/distributedtask/webhooks/<WebHook Name>?api-version=6.0-preview`. 
+The WebHook Name must match that of the Incoming WebHook Service Connection.
+This endpoint is publicly available, and no authorization is needed. The request should have the following body.
 
 ```json
 {


### PR DESCRIPTION
## Summary

#### For Azure DevOps webhooks, the `webhook` value in yml must be `WebHook`.

- If a value other than `WebHook` is specified, "Key not found 'WebHook'" error occurs.
![Screenshot 2024-08-13 164535](https://github.com/user-attachments/assets/63888803-1346-4dd0-93f1-3ed5266af34b)

#### The URL must specify the WebHook Name.

- The URL must be the WebHook Name of the Incoming Webhook Service Connection. The name <webhook_connection_name> is ambiguous and misleading.
- The following site's explanation is correct. The notations need to be matched.
https://learn.microsoft.com/en-us/azure/devops/release-notes/2020/pipelines/sprint-172-update?WT.mc_id=DOP-MVP-21138#generic-webhook-based-triggers-for-yaml-pipelines


