### PR TITLE
Update download-package-v1.md

### DIFF
--- a/task-reference/download-package-v1.md
+++ b/task-reference/download-package-v1.md
@@ -127,7 +127,7 @@ If you don't find the package in the list, you can provide the package ID, which
 **`version`** - **Version**<br>
 `string`. Required.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-Specifies the version of the package. Use `latest` to download the latest version of the package at runtime.
+Specifies the version of the package. Use `latest` to download the latest version of the package at runtime. Use `*` to download the latest version of a package when `packageType = upack`.
 <!-- :::editable-content-end::: -->
 <br>
 


### PR DESCRIPTION
If "packageType = upack", then latest is not available. You must use "*" instead. If you use “latest”, the following error will be logged in the pipeline log

> ##[error]An unexpected error occurred while trying to download the package. Exit code(20) and error({"@t":"2024-08-15T01:06:54.9437476Z","@m":"The package version provided is invalid. Universal package versions must be lowercase SemVer 2.0 versions without build metadata. The package version must be under 128 characters, and major/minor/patch must each be less than or equal to 2147483647.","@i":"67cc01dd","@l":"Error","SourceContext":"ArtifactTool.Program","UtcTimestamp":"2024-08-15 01:06:54.943Z"})

Thank you for your contribution. Please see the README.MD in this repo for details on how to contribute.

- [x] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [x] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.