### PR TITLE
updated doc for publish test results v2 - merge test results option

### DIFF
--- a/task-reference/publish-test-results-v2.md
+++ b/task-reference/publish-test-results-v2.md
@@ -159,7 +159,7 @@ Optional. Specifies the folder to search for the test result files.
 **`mergeTestResults`** - **Merge test results**<br>
 `boolean`. Default value: `false`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-When this boolean's value is `true`, the task reports test results from all the files against a single [test run](/azure/devops/pipelines/test/test-glossary). If the value is `false`, the task creates a separate test run for each test result file.
+When this boolean's value is `true`, the task reports test results from all the files against a single [test run](/azure/devops/pipelines/test/test-glossary). If the value is `false`, the task creates a separate test run for each test result file. To optimize for better performance, results will be merged into a single run if there are more than 100 result files, irrespective of this option.
 
 > [!NOTE]
 > Use the merge test results setting to combine files from the same test framework to ensure results mapping and duration are calculated correctly.

--- a/task-reference/publish-test-results-v2.md
+++ b/task-reference/publish-test-results-v2.md
@@ -159,7 +159,7 @@ Optional. Specifies the folder to search for the test result files.
 **`mergeTestResults`** - **Merge test results**<br>
 `boolean`. Default value: `false`.<br>
 <!-- :::editable-content name="helpMarkDown"::: -->
-When this boolean's value is `true`, the task reports test results from all the files against a single [test run](/azure/devops/pipelines/test/test-glossary). If the value is `false`, the task creates a separate test run for each test result file. To optimize for better performance, results will be merged into a single run if there are more than 100 result files, irrespective of this option.
+When this boolean's value is `true`, the task reports test results from all the files against a single [test run](/azure/devops/pipelines/test/test-glossary). If the value is `false`, the task creates a separate test run for each test result file. To optimize for better performance, results will always be merged into a single run if there are more than 100 result files even if this option is set to `false`.
 
 > [!NOTE]
 > Use the merge test results setting to combine files from the same test framework to ensure results mapping and duration are calculated correctly.


### PR DESCRIPTION
Updated documentation for merge test results to include limit of 100 files.

(ref: this is according to the info bubble shown at the same option in the UI as per below)
![image](https://github.com/user-attachments/assets/f092da70-77aa-438c-b4e6-b8eb1391d225)
