### PR TITLE
Explain how to allow build pipelines to pull pypi packages from upstream sources

### DIFF
--- a/task-reference/pip-authenticate-v1.md
+++ b/task-reference/pip-authenticate-v1.md
@@ -108,7 +108,7 @@ This task must run before you use pip to download Python distributions to an aut
 
 ### What if I want my pipelines to be able to save from upstream sources?
 
-Check the [permissions table](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/access-tokens?view=azure-devops&tabs=yaml#scoped-build-identities) to determine what permissions you want your pipeline to have. Then, determine which [identity](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/access-tokens?view=azure-devops&tabs=yaml#scoped-build-identities) you want to give those permissions to. To save packages from upstream sources, your identity needs `Feed and Upstream Reader (Collaborator)` permissions.
+Check the [permissions table](https://learn.microsoft.com/azure/devops/artifacts/feeds/feed-permissions#pipelines-permissions) to determine what permissions you want your pipeline to have. Then, determine which [identity](https://learn.microsoft.com/azure/devops/pipelines/process/access-tokens#scoped-build-identities) you want to give those permissions to. To save packages from upstream sources, your identity needs `Feed and Upstream Reader (Collaborator)` permissions.
 
 ### My agent is behind a web proxy. Will PipAuthenticate set up pip to use my proxy?
 

--- a/task-reference/pip-authenticate-v1.md
+++ b/task-reference/pip-authenticate-v1.md
@@ -98,12 +98,17 @@ None.
 Provides authentication for the `pip` client that is used to install Python distributions.
 
 * [When in my pipeline should I run this task?](#when-in-my-pipeline-should-i-run-this-task)
+* [What if I want my pipelines to be able to save from upstream sources?](#what-if-i-want-my-pipelines-to-be-able-to-save-from-upstream-sources)
 * [My agent is behind a web proxy. Will PipAuthenticate set up pip to use my proxy?](#my-agent-is-behind-a-web-proxy-will-pipauthenticate-set-up-pip-to-use-my-proxy)
 * [My Pipeline needs to access a feed in a different project](#my-pipeline-needs-to-access-a-feed-in-a-different-project)
 
 ### When in my pipeline should I run this task?
 
 This task must run before you use pip to download Python distributions to an authenticated package source such as Azure Artifacts. There are no other ordering requirements. Multiple invocations of this task will not stack credentials. Every run of the task will erase any previously stored credentials.
+
+### What if I want my pipelines to be able to save from upstream sources?
+
+Check the [permissions table](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/access-tokens?view=azure-devops&tabs=yaml#scoped-build-identities) to determine what permissions you want your pipeline to have. Then, determine which [identity](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/access-tokens?view=azure-devops&tabs=yaml#scoped-build-identities) you want to give those permissions to. To save packages from upstream sources, your identity needs `Feed and Upstream Reader (Collaborator)` permissions.
 
 ### My agent is behind a web proxy. Will PipAuthenticate set up pip to use my proxy?
 

--- a/task-reference/pip-authenticate-v1.md
+++ b/task-reference/pip-authenticate-v1.md
@@ -108,7 +108,7 @@ This task must run before you use pip to download Python distributions to an aut
 
 ### What if I want my pipelines to be able to save from upstream sources?
 
-Check the [permissions table](https://learn.microsoft.com/azure/devops/artifacts/feeds/feed-permissions#pipelines-permissions) to determine what permissions you want your pipeline to have. Then, determine which [identity](https://learn.microsoft.com/azure/devops/pipelines/process/access-tokens#scoped-build-identities) you want to give those permissions to. To save packages from upstream sources, your identity needs `Feed and Upstream Reader (Collaborator)` permissions.
+Check the [permissions table](/azure/devops/artifacts/feeds/feed-permissions#pipelines-permissions) to determine what permissions you want your pipeline to have. Then, determine which [identity](/azure/devops/pipelines/process/access-tokens#scoped-build-identities) you want to give those permissions to. To save packages from upstream sources, your identity needs `Feed and Upstream Reader (Collaborator)` permissions.
 
 ### My agent is behind a web proxy. Will PipAuthenticate set up pip to use my proxy?
 


### PR DESCRIPTION
Explain how to allow build pipelines to pull pypi packages from upstream sources

This documentation seemed very hidden. Adding references here so people are aware this is an option.



Thank you for your contribution. Please see the README.MD in this repo for details on how to contribute.

- [X] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [X] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.