### PR TITLE
Update advanced-security-codeql-init-v1.md - build-mode none docs

### DIFF
--- a/task-reference/advanced-security-codeql-init-v1.md
+++ b/task-reference/advanced-security-codeql-init-v1.md
@@ -139,7 +139,7 @@ You can specify `threads` here in the task, or you can specify it in a pipeline 
 You can provide multiple paths separated by commas. The paths must be relative to the `sourcesfolder` where CodeQL is running, which defaults to the `Build.SourcesDirectory` pipeline environment variable. For example, to ignore the `$(Build.SourcesDirectory)/donotscan` directory, set `codeqlpathstoignore: donotscan` rather than `codeqlpathstoignore: $(Build.SourcesDirectory)/donotscan`.
 
 > [!IMPORTANT]
-> The `codeqlpathstoignore` setting applies only when you run the CodeQL tasks on an interpreted language (Python, Ruby, and JavaScript/TypeScript).
+> The `codeqlpathstoignore` setting applies only when you run the CodeQL tasks on an interpreted language (Python, Ruby, and JavaScript/TypeScript) or when you analyze a compiled language without building the code (currently supported for C# and Java).
 <!-- :::editable-content-end::: -->
 <br>
 
@@ -154,7 +154,7 @@ You can provide multiple paths separated by commas. The paths must be relative t
 You can provide multiple paths separated by commas. The paths must be relative to the `sourcesfolder` where CodeQL is running, which defaults to the `Build.SourcesDirectory` pipeline environment variable. For example, to include the `$(Build.SourcesDirectory)/app` directory, set `codeqlpathstoinclude: app` rather than `codeqlpathstoinclude: $(Build.SourcesDirectory)/app`.
 
 > [!IMPORTANT]
-> The `codeqlpathstoinclude` setting applies only when you run the CodeQL tasks on an interpreted language (Python, Ruby, and JavaScript/TypeScript).
+> The `codeqlpathstoinclude` setting applies only when you run the CodeQL tasks on an interpreted language (Python, Ruby, and JavaScript/TypeScript) or when you analyze a compiled language without building the code (currently supported for C# and Java).
 <!-- :::editable-content-end::: -->
 <br>
 


### PR DESCRIPTION

build-mode none docs to sync up with github docs: https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#specifying-directories-to-scan


The most important changes include:

* Updated the description of the `codeqlpathstoignore` setting to clarify that it applies not only to interpreted languages but also to compiled languages without building the code, specifically C# and Java.
* Updated the description of the `codeqlpathstoinclude` setting to include the same clarification regarding its applicability to compiled languages without building the code, specifically C# and Java.