### PR TITLE
Replace "manual" with "gitTag" in GitHubRelease v1 example

### DIFF
--- a/task-reference/github-release-v1.md
+++ b/task-reference/github-release-v1.md
@@ -343,7 +343,7 @@ The following YAML creates a GitHub release every time the task runs. The build 
   inputs:
     gitHubConnection: zenithworks
     repositoryName: zenithworks/javaAppWithMaven
-    tagSource: manual
+    tagSource: gitTag
     tag: $(Build.BuildNumber)      
     assets: |
       $(Build.ArtifactStagingDirectory)/*.exe


### PR DESCRIPTION
Thank you for your contribution. Please see the README.MD in this repo for details on how to contribute.

- [x] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [x] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.

---

This example still used v0's "manual" tagSource option. v1 uses "gitTag".