### PR TITLE
Updated documentation to use 'NuGetAuthenticate' to refresh credentials

### DIFF
--- a/task-reference/nuget-command-v2.md
+++ b/task-reference/nuget-command-v2.md
@@ -635,6 +635,23 @@ Starting with Ubuntu 24.04, Microsft-hosted agents [will not ship with mono](htt
 The [NuGet Authenticate](nuget-authenticate-v1.md) task will handle injecting credentials into the needed places for client tools to authenticate as your pipeline identity. Please see the linked documentation for instructions, FAQs, and examples for using `NuGet Authenticate` with dotnet.
 
 If [dotnet CLI commands](/nuget/reference/dotnet-commands) do not support your scenario, please [report this to the .NET CLI team as an issue](https://github.com/NuGet/Home/issues/). You may continue to [pin your agent image](/azure/devops/pipelines/agents/pools-queues#designate-a-pool-in-your-pipeline) to [Ubuntu 22.04 or earlier](/azure/devops/pipelines/agents/hosted#software). Ubuntu 22.04 support will continue until Ubuntu 26.04 is made generally available, no earlier than 2026.
+
+### Why is the build pipeline failing and requesting Single Sign-On (SSO) for authentication?
+
+Build can fail due to expired credentials. Use the [NuGet Authenticate](nuget-authenticate-v1.md) task to prevent failures caused by expired credentials, as it can reinstall the credential provider and refresh the credentials. 
+
+```yaml
+steps:
+# Authenticate with NuGet to ensure credentials are refreshed
+- task: NuGetAuthenticate@1
+# Restore NuGet packages
+- task: NuGetCommand@2
+  inputs:
+    command: 'restore'
+    restoreSolution: '**/*.sln'
+    feedsToUse: 'select'
+```
+
 <!-- :::editable-content-end::: -->
 <!-- :::remarks-end::: -->
 

--- a/task-reference/nuget-command-v2.md
+++ b/task-reference/nuget-command-v2.md
@@ -636,9 +636,9 @@ The [NuGet Authenticate](nuget-authenticate-v1.md) task will handle injecting cr
 
 If [dotnet CLI commands](/nuget/reference/dotnet-commands) do not support your scenario, please [report this to the .NET CLI team as an issue](https://github.com/NuGet/Home/issues/). You may continue to [pin your agent image](/azure/devops/pipelines/agents/pools-queues#designate-a-pool-in-your-pipeline) to [Ubuntu 22.04 or earlier](/azure/devops/pipelines/agents/hosted#software). Ubuntu 22.04 support will continue until Ubuntu 26.04 is made generally available, no earlier than 2026.
 
-### Why is the build pipeline failing and requesting Single Sign-On (SSO) for authentication?
+### Why is my build pipeline failing and prompting for Single Sign-On (SSO) authentication?
 
-Build can fail due to expired credentials. Use the [NuGet Authenticate](nuget-authenticate-v1.md) task to prevent failures caused by expired credentials, as it can reinstall the credential provider and refresh the credentials. 
+Builds can fail if credentials have expired. To avoid these failures, we recommend using the [NuGet Authenticate](nuget-authenticate-v1.md) task to reinstall the credential provider and automatically refresh credentials. This ensures uninterrupted access during pipeline execution.
 
 ```yaml
 steps:

--- a/task-reference/nuget-restore-v1.md
+++ b/task-reference/nuget-restore-v1.md
@@ -215,6 +215,21 @@ None.
 
 <!-- :::remarks::: -->
 <!-- :::editable-content name="remarks"::: -->
+## Remarks
+
+### Why is the build pipeline failing and requesting Single Sign-On (SSO) for authentication?
+
+Build can fail due to expired credentials. Use the [NuGet Authenticate](nuget-authenticate-v1.md) task to prevent failures caused by expired credentials, as it can reinstall the credential provider and refresh the credentials. 
+
+```yaml
+steps:
+# Authenticate with NuGet to ensure credentials are refreshed
+- task: NuGetAuthenticate@1
+# Restore NuGet packages
+- task: NuGetRestore@1
+  inputs:
+    solution: '**/*.sln'
+```
 <!-- :::editable-content-end::: -->
 <!-- :::remarks-end::: -->
 

--- a/task-reference/nuget-restore-v1.md
+++ b/task-reference/nuget-restore-v1.md
@@ -217,9 +217,9 @@ None.
 <!-- :::editable-content name="remarks"::: -->
 ## Remarks
 
-### Why is the build pipeline failing and requesting Single Sign-On (SSO) for authentication?
+### Why is my build pipeline failing and prompting for Single Sign-On (SSO) authentication?
 
-Build can fail due to expired credentials. Use the [NuGet Authenticate](nuget-authenticate-v1.md) task to prevent failures caused by expired credentials, as it can reinstall the credential provider and refresh the credentials. 
+Builds can fail if credentials have expired. To avoid these failures, we recommend using the [NuGet Authenticate](nuget-authenticate-v1.md) task to reinstall the credential provider and automatically refresh credentials. This ensures uninterrupted access during pipeline execution.
 
 ```yaml
 steps:
@@ -230,6 +230,7 @@ steps:
   inputs:
     solution: '**/*.sln'
 ```
+
 <!-- :::editable-content-end::: -->
 <!-- :::remarks-end::: -->
 

--- a/task-reference/vsbuild-v1.md
+++ b/task-reference/vsbuild-v1.md
@@ -311,9 +311,9 @@ None.
 <!-- :::editable-content name="remarks"::: -->
 ## Remarks
 
-### Why is the build pipeline failing and requesting Single Sign-On (SSO) for authentication?
+### Why is my build pipeline failing and prompting for Single Sign-On (SSO) authentication?
 
-Build can fail due to expired credentials. Use the [NuGet Authenticate](nuget-authenticate-v1.md) task to prevent failures caused by expired credentials, as it can reinstall the credential provider and refresh the credentials. 
+Builds can fail if credentials have expired. To avoid these failures, we recommend using the [NuGet Authenticate](nuget-authenticate-v1.md) task to reinstall the credential provider and automatically refresh credentials. This ensures uninterrupted access during pipeline execution.
 
 ```yaml
 steps:

--- a/task-reference/vsbuild-v1.md
+++ b/task-reference/vsbuild-v1.md
@@ -311,6 +311,19 @@ None.
 <!-- :::editable-content name="remarks"::: -->
 ## Remarks
 
+### Why is the build pipeline failing and requesting Single Sign-On (SSO) for authentication?
+
+Build can fail due to expired credentials. Use the [NuGet Authenticate](nuget-authenticate-v1.md) task to prevent failures caused by expired credentials, as it can reinstall the credential provider and refresh the credentials. 
+
+```yaml
+steps:
+# Authenticate with NuGet to ensure credentials are refreshed
+- task: NuGetAuthenticate@1 
+# Build the solution using VSBuild
+- task: VSBuild@1
+  inputs:
+    solution: '**/*.sln' 
+```
 Learn more about installing [Visual Studio images on Azure](/visualstudio/install/using-visual-studio-vm).
 
 > [!IMPORTANT]


### PR DESCRIPTION
Fixes AB#2237708

Build using task Nuget Command, Vsbuild or Nuget Restore can fail because of expired credentials. Use task 'NuGetAuthenticate' prior to keep credentials refreshed.

Thank you for your contribution. Please see the README.MD in this repo for details on how to contribute.

- [ ] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [x] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.