### PR TITLE
Update index.md

### DIFF
--- a/task-reference/index.md
+++ b/task-reference/index.md
@@ -302,7 +302,7 @@ For how-tos and tutorials about authoring pipelines using tasks, including creat
 | **IIS web app manage**<br>[IISWebAppManagementOnMachineGroup@0](iisweb-app-management-on-machine-group-v0.md) | Create or update websites, web apps, virtual directories, or application pools. |
 | **Invoke REST API**<br>[InvokeRESTAPI@1](invoke-rest-api-v1.md)<br>[InvokeRESTAPI@0](invoke-rest-api-v0.md) | Invoke a REST API as a part of your pipeline. |
 | **Kubectl**<br>[Kubernetes@1](kubernetes-v1.md)<br>[Kubernetes@0](kubernetes-v0.md) | Deploy, configure, update a Kubernetes cluster in Azure Container Service by running kubectl commands. |
-| **Manual intervention**<br>[ManualIntervention@8](manual-intervention-v8.md) | Pause deployment and wait for manual intervention. |
+| **Manual intervention**<br>[ManualIntervention@8](manual-intervention-v8.md) | Pause deployment and wait for manual intervention. Works only with classic release pipelines. |
 | **Manual validation**<br>[ManualValidation@0](manual-validation-v0.md) | [PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines. |
 | **MySQL database deploy**<br>[MysqlDeploymentOnMachineGroup@1](mysql-deployment-on-machine-group-v1.md) | Run scripts and make changes to a MySQL Database. |
 | **Package and deploy Helm charts**<br>[HelmDeploy@0](helm-deploy-v0.md) | Deploy, configure, update a Kubernetes cluster in Azure Container Service by running helm commands. |


### PR DESCRIPTION
ManualIntervention@8 page has been updated to highlight it is only used for classic release pipeline. Updating index to reflect on the same.

Thank you for your contribution. Please see the README.MD in this repo for details on how to contribute.

- [ ] Are you creating a new task article? If yes, STOP. New task articles are auto-generated when the new task is deployed to an Azure DevOps sprint, including all task inputs, aliases, defaults, and allowed values. Once the task deploys and the article is generated, you can make a PR to add examples, remarks, and descriptions. If you have a readme.md file in the tasks repo for your new task, that content will be picked up as well. If you have a section in the readme.md file that explains what makes this new version of the task different than the previous version, that is greatly appreciated.
- [ ] Are you editing a task or YAML schema definition article? We welcome your contributions to content that is contained within "editable-content" tags. Any contributions outside of an "editable-content" tag won't be merged as these articles are auto-generated (and auto-updated when new properties or inputs are deployed), with the exception of the content inside "editable-content" tags.