### PR TITLE
Remove comparison section for 'extends' and 'include'

### DIFF
--- a/content/extends.md
+++ b/content/extends.md
@@ -75,11 +75,6 @@ The `extends` keyword allows a pipeline to use another pipeline (or template) as
 - **Template inheritance**: Build pipelines from templates with parameters
 
 A pipeline can extend a single template. The template file should be a complete, valid pipeline structure. When you use `extends`, your pipeline YAML becomes a template that references the base template and optionally overrides parameters.
-
-### Extends vs includes
-
-- **`extends`**: Creates a pipeline that inherits from a template. Used at the root level of a pipeline.
-- **`include`**: Imports template content directly. Used at specific points within a pipeline.
 <!-- :::editable-content-end::: -->
 <!-- :::remarks-end::: -->
 


### PR DESCRIPTION
There _is_ an `include` keyword in Azure Pipelines YAML, but it's to do with [pipeline triggers](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/trigger?view=azure-pipelines#trigger-batch-branches-paths-tags). It doesn't import template content, and doesn't have anything to do with `extends`.